### PR TITLE
feat(headless): Add support for running headless chrome/FF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: node_js
 node_js:
 - '8'
 addons:
-  firefox: '54.0'
+  firefox: '56.0'
   chrome: stable
 branch:
   only:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1564,12 +1564,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
-      "dev": true
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -1902,12 +1896,6 @@
         "supports-color": "4.4.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-          "dev": true
-        },
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -1921,6 +1909,18 @@
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
           "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+          "dev": true
+        },
+        "growl": {
+          "version": "1.10.3",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+          "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
         "supports-color": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,7 +23,6 @@ export interface IConfig extends ISnappitConfig {
     headless?: boolean;
     paths?: IConfigPaths;
     serverUrl?: string;
-    useDirect?: boolean;
     useProvidedDriver?: boolean;
 }
 
@@ -37,11 +36,12 @@ export function prepareConfig(config: IConfig): IConfig {
 
 const defaultConfig: IConfig = {
     browser: "chrome",
+    headless: false,
     logException: [],
     paths: getBinaryPaths(),
     screenshotsDir: "./screenshots",
+    serverUrl: "http://localhost:4444/wd/hub",
     threshold: 0.04,
-    useDirect: false,
     useProvidedDriver: false,
 };
 
@@ -65,18 +65,6 @@ function validateConfig(
     const isValidBrowser = _.includes(validBrowsers, config.browser);
     if (!config.useProvidedDriver && !isValidBrowser) {
         throw new Error('Configuration error: Please set a "browser" of either "chrome" or "firefox".');
-    }
-
-    // useDirect and !_.isEmpty both return booleans, so we can !== them for an XOR.
-    const isValidLocation = config.useDirect !== !_.isEmpty(config.serverUrl);
-    if (!config.useProvidedDriver && !isValidLocation) {
-        throw new Error("Configuration error: Please do only one of the following: " +
-            'set "useDirect => true" OR provide a "serverUrl" option.');
-    }
-
-    if (config.headless && config.useDirect) {
-        throw new Error("Configuration error: Using headless mode with direct connect is unsupported. " +
-            "Include a serverUrl, or set headless to false.");
     }
 
     const isValidThreshold = config.threshold && config.threshold >= 0 && config.threshold <= 0.99;

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,8 @@ export interface ISnappitConfig {
 }
 
 export interface IConfig extends ISnappitConfig {
-    browser?: string;
+    browser: string;
+    headless?: boolean;
     paths?: IConfigPaths;
     serverUrl?: string;
     useDirect?: boolean;
@@ -63,19 +64,24 @@ function validateConfig(
 
     const isValidBrowser = _.includes(validBrowsers, config.browser);
     if (!config.useProvidedDriver && !isValidBrowser) {
-        throw new Error('Configuration error:  Please set a "browser" of either "chrome" or "firefox".');
+        throw new Error('Configuration error: Please set a "browser" of either "chrome" or "firefox".');
     }
 
     // useDirect and !_.isEmpty both return booleans, so we can !== them for an XOR.
     const isValidLocation = config.useDirect !== !_.isEmpty(config.serverUrl);
     if (!config.useProvidedDriver && !isValidLocation) {
-        throw new Error("Configuration error:  Please do only one of the following:" +
-            'set "useDirect => true" OR provide a "serverUrl" option.');
+        throw new Error("Configuration error: Please do only one of the following: " +
+                        'set "useDirect => true" OR provide a "serverUrl" option.');
+    }
+
+    if (config.headless && config.useDirect) {
+        throw new Error("Configuration error: Using headless mode with direct connect is unsupported. " +
+                        "Include a serverUrl, or set headless to false.");
     }
 
     const isValidThreshold = config.threshold && config.threshold >= 0 && config.threshold <= 0.99;
     if (!isValidThreshold) {
-        throw new Error('Configuration error:  Please set a "threshold" between 0 and 0.99');
+        throw new Error('Configuration error: Please set a "threshold" between 0 and 0.99');
     }
 
     const exceptions: string[] = [
@@ -86,6 +92,6 @@ function validateConfig(
     const isValidLogException = config.logException.every((value) => exceptions.indexOf(value) >= 0);
     if (!isValidLogException) {
         throw new Error('Configuration error: "logException" should be an array with zero or more ' +
-            `exception names: "${exceptions.join('", "')}".`);
+                        `exception names: "${exceptions.join('", "')}".`);
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,12 +71,12 @@ function validateConfig(
     const isValidLocation = config.useDirect !== !_.isEmpty(config.serverUrl);
     if (!config.useProvidedDriver && !isValidLocation) {
         throw new Error("Configuration error: Please do only one of the following: " +
-                        'set "useDirect => true" OR provide a "serverUrl" option.');
+            'set "useDirect => true" OR provide a "serverUrl" option.');
     }
 
     if (config.headless && config.useDirect) {
         throw new Error("Configuration error: Using headless mode with direct connect is unsupported. " +
-                        "Include a serverUrl, or set headless to false.");
+            "Include a serverUrl, or set headless to false.");
     }
 
     const isValidThreshold = config.threshold && config.threshold >= 0 && config.threshold <= 0.99;
@@ -92,6 +92,6 @@ function validateConfig(
     const isValidLogException = config.logException.every((value) => exceptions.indexOf(value) >= 0);
     if (!isValidLogException) {
         throw new Error('Configuration error: "logException" should be an array with zero or more ' +
-                        `exception names: "${exceptions.join('", "')}".`);
+            `exception names: "${exceptions.join('", "')}".`);
     }
 }

--- a/src/getDriver.ts
+++ b/src/getDriver.ts
@@ -54,35 +54,25 @@ function ThenableWebDriver<T extends Constructor<Webdriver.WebDriver>>(
 export function getDriver(
     config: IConfig,
 ): Webdriver.ThenableWebDriver {
-    // The default is to expect the remote case, so check for useDirect here.
-    if (config.useDirect) {
-        const isChrome = (config.browser === Webdriver.Browser.CHROME);
-        const browser: IBrowserDriver = isChrome ? Chrome : Firefox;
-        const executor = isChrome ? config.paths.chromeExe : config.paths.geckoExe;
-        const srv = new browser.ServiceBuilder(executor).build();
-
-        // Must cast here because TypeScript has no way of knowing we've modified the return value of createSession.
-        return ThenableWebDriver(browser.Driver).createSession(null, srv) as Webdriver.ThenableWebDriver;
-    }
-
     const builder = new Webdriver.Builder()
         .usingServer(config.serverUrl)
         .forBrowser(config.browser);
 
-    let options: Firefox.Options | Chrome.Options;
-    if (config.browser === Webdriver.Browser.FIREFOX) {
-        options = new Firefox.Options();
-        if (config.headless) {
+    if (config.headless) {
+        if (config.browser === Webdriver.Browser.FIREFOX) {
+            const options = new Firefox.Options();
             const binary = new Firefox.Binary();
-            binary.addArguments("--headless");
-            options.setBinary(binary);
-        }
 
-        builder.setFirefoxOptions(options as Firefox.Options);
-    } else if (config.browser === Webdriver.Browser.CHROME && config.headless) {
-        const capabilities = Webdriver.Capabilities.chrome();
-        capabilities.set("chromeOptions", { args: ["--headless"] });
-        builder.withCapabilities(capabilities);
+            binary.addArguments("-headless");
+            options.setBinary(binary);
+            builder.setFirefoxOptions(options);
+
+        } else if (config.browser === Webdriver.Browser.CHROME) {
+            const capabilities = Webdriver.Capabilities.chrome();
+
+            capabilities.set("chromeOptions", { args: ["--headless"] });
+            builder.withCapabilities(capabilities);
+        }
     }
 
     return builder.build();

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -36,10 +36,9 @@ export class Screenshot {
         driver: ThenableWebDriver,
         element?: WebElementPromise,
     ): Promise<Screenshot> {
-        // This handles chrome because it doesn't impmlement element.takeScreenshot() yet.
-        // const isChrome = (await driver.getCapabilities()).get("browserName") === "chrome";
+        // This handles chrome, firefox headless, because they don't impmlement element.takeScreenshot() yet.
         if (element) {
-            return this.chromeCanvasScreenshot(driver, element);
+            return this.canvasScreenshot(driver, element);
         }
 
         const buffer = new Buffer(await (element ? element : driver).takeScreenshot(), "base64");
@@ -52,7 +51,7 @@ export class Screenshot {
      * This is a workaround to screenshotting an element in chrome because chromedriver does not
      * implement WebElement.takeScreenshot
      */
-    public static async chromeCanvasScreenshot(
+    public static async canvasScreenshot(
         driver: ThenableWebDriver,
         element: WebElementPromise,
     ): Promise<Screenshot> {

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -37,8 +37,8 @@ export class Screenshot {
         element?: WebElementPromise,
     ): Promise<Screenshot> {
         // This handles chrome because it doesn't impmlement element.takeScreenshot() yet.
-        const isChrome = (await driver.getCapabilities()).get("browserName") === "chrome";
-        if (element && isChrome) {
+        // const isChrome = (await driver.getCapabilities()).get("browserName") === "chrome";
+        if (element) {
             return this.chromeCanvasScreenshot(driver, element);
         }
 

--- a/src/screenshot.ts
+++ b/src/screenshot.ts
@@ -18,10 +18,11 @@ export class Screenshot {
     ): Promise<string> {
         const capabilities = await driver.getCapabilities();
         const size = await driver.manage().window().getSize();
+        const version = (capabilities.get("version") || capabilities.get("browserVersion"));
         const screenshotPath = path.resolve(screenshotsDir);
         return path.join(screenshotPath, name)
             .replace("{browserName}", capabilities.get("browserName"))
-            .replace("{browserVersion}", capabilities.get("version"))
+            .replace("{browserVersion}", version)
             .replace("{browserSize}", `${size.width}x${size.height}`)
             .replace(/.png$/, "")
             .split(path.sep)

--- a/src/snappit.ts
+++ b/src/snappit.ts
@@ -103,6 +103,8 @@ export class Snappit {
         } catch (e) {
             // Ignore the driver quit error
         }
+
+        this.driver = undefined;
     }
 
     public $(
@@ -132,14 +134,12 @@ export class Snappit {
         // Baseline image exists
         if (fs.existsSync(filePath)) {
             const oldShot = Screenshot.fromPath(filePath);
+            const diff = newShot.percentDiff(oldShot);
 
             if (!newShot.isSameSize(oldShot)) {
                 newShot.saveToPath(filePath);
                 this.handleException(new ScreenshotSizeDifferenceException(filePath));
-            }
-
-            const diff = newShot.percentDiff(oldShot);
-            if (diff > this.config.threshold) {
+            } else if (diff > this.config.threshold) {
                 const prettyDiff = (diff * 100).toFixed(2) + "%";
                 const message = `Screenshots do not match within threshold. ${prettyDiff} difference.`;
                 newShot.saveToPath(filePath);

--- a/test/snappit.spec.ts
+++ b/test/snappit.spec.ts
@@ -17,6 +17,10 @@ import {
 } from "../src/errors";
 import {$, snap, Snappit} from "../src/snappit";
 
+async function resetViewport(driver: ThenableWebDriver) {
+    await driver.manage().window().setSize(1366, 768);
+}
+
 function browserTest(
     name: string,
     config: IConfig,
@@ -163,15 +167,14 @@ describe("Snappit", () => {
             // Initialize Snappit
             const config: IConfig = {
                 browser: "chrome",
+                headless: true,
                 screenshotsDir: "test/screenshots",
+                serverUrl: "http://localhost:4444/wd/hub",
                 threshold: 0.1,
-                useDirect: true,
             };
-
             snappit = new Snappit(config);
             driver = snappit.start();
-
-            await driver.manage().window().setSize(960, 768); // Slightly smaller than TravisCI
+            await resetViewport(driver);
             await driver.get("http://localhost:8080/");
         });
 
@@ -183,7 +186,7 @@ describe("Snappit", () => {
             try {
                 snap.configure({ threshold: 1.01 });
             } catch (e) {
-                expect(e.message).to.equal('Configuration error:  Please set a "threshold" between 0 and 0.99');
+                expect(e.message).to.equal('Configuration error: Please set a "threshold" between 0 and 0.99');
             }
         });
 
@@ -236,7 +239,7 @@ describe("Snappit", () => {
             await snap("chrome-throw-no-oversized-crop.png", $("#color-div")).catch((err) => err);
             await driver.manage().window().setSize(100, 100);
             await snap("chrome-throw-no-oversized-crop.png", $("#color-div"));
-            await driver.manage().window().setSize(960, 768); // Slightly smaller than TravisCI
+            await resetViewport(driver);
         });
 
         describe("and reconfiguring at runtime", () => {
@@ -274,8 +277,7 @@ describe("Snappit", () => {
 
             snappit = new Snappit(config);
             driver = snappit.start();
-
-            await driver.manage().window().setSize(960, 768); // Slightly smaller than TravisCI
+            await resetViewport(driver);
             await driver.get("http://localhost:8080/");
         });
 

--- a/test/snappit.spec.ts
+++ b/test/snappit.spec.ts
@@ -3,7 +3,8 @@ import * as childProcess from "child_process";
 import {expect} from "chai";
 import * as fs from "fs-extra";
 import * as _ from "lodash";
-import {By, ISize, ThenableWebDriver, WebDriver} from "selenium-webdriver";
+import * as path from "path";
+import {By, ISize, ThenableWebDriver, WebDriver, WebElementPromise} from "selenium-webdriver";
 
 import {IConfig, ISnappitConfig} from "../src/config";
 
@@ -17,112 +18,36 @@ import {
 } from "../src/errors";
 import {$, snap, Snappit} from "../src/snappit";
 
-async function resetViewport(driver: ThenableWebDriver) {
-    await driver.manage().window().setSize(1366, 768);
+async function resizeViewport(
+    driver: ThenableWebDriver,
+    width: number = 1366,
+    height: number = 768,
+): Promise<void> {
+    await driver.manage().window().setSize(width, height);
 }
+
+type ISuiteFn = typeof describe | typeof describe.only | typeof describe.skip;
 
 function browserTest(
-    name: string,
+    suiteName: string,
     config: IConfig,
-    driver?: ThenableWebDriver,
-    skip?: boolean,
+    suiteFn: ISuiteFn = describe,
 ): void {
-    const suiteFn = skip ? describe.skip : describe;
 
-    suiteFn(name, function() {
-        let snappit: Snappit;
-        this.timeout(15000);
-        this.slow(2500);
-
-        before(() => {
-            snappit = new Snappit(config, driver);
-        });
-
-        if (!driver) {
-            it("should create a driver instance", async () => {
-                // Snappit will throw if there is a problem in driver creation.
-                driver = snappit.start();
-                await driver;
-            });
-        } else {
-            driver = driver as ThenableWebDriver;
-        }
-
-        it("should navigate to the localhost page", async () => {
-            // Cast here as TypeScript thinks driver might not be initialized.
-            driver.get("http://localhost:8080/");
-
-            expect(await $("#color-div").isDisplayed()).to.eql(true);
-        });
-
-        it("should terminate the driver instances", async () => {
-            await snappit.stop();
-        });
-    });
-}
-
-// This namespace is just used for declaration merging convenience for .skip
-/* tslint:disable-next-line:no-namespace */
-namespace browserTest {
-    export function skip(
-        name: string,
-        config: IConfig,
-        driver?: ThenableWebDriver,
-    ): void {
-        browserTest(name, config, driver, true);
-    }
-}
-
-describe("Snappit", () => {
-
-    describe("with useDirect set", () => {
-
-        browserTest("Chrome", {
-            browser: "chrome",
-            useDirect: true,
-        });
-
-        browserTest("FireFox", {
-            browser: "firefox",
-            useDirect: true,
-        });
-
-    });
-
-    // Using the default server URL
-    describe("when using a remote server", () => {
-
-        browserTest("Chrome", {
-            browser: "chrome",
-            serverUrl: "http://localhost:4444/wd/hub",
-            useDirect: false,
-        });
-
-        browserTest("GeckoDriver FireFox", {
-            browser: "firefox",
-            serverUrl: "http://localhost:4444/wd/hub",
-            useDirect: false,
-        });
-
-    });
-
-    describe("$ and snap shorthand methods", function() {
-        let snappit: Snappit;
+    suiteFn(suiteName, function() {
         let driver: ThenableWebDriver;
+        let snappit: Snappit;
         this.timeout(15000);
         this.slow(2500);
 
         before(() => {
-            // Initialize Snappit
-            const config: IConfig = {
-                browser: "chrome",
-                useDirect: true,
-            };
+            config.screenshotsDir = `./test/screenshots/${suiteName}`;
+            config.threshold = 0.1;
 
             snappit = new Snappit(config);
         });
 
-        describe("before 'snappit.start()", () => {
+        describe("before 'snappit.start()'", () => {
             it("should throw an error on invoking '$'", () => {
                 const fn = $ as () => any;
                 expect(fn).to.throw(NoDriverSessionException);
@@ -134,10 +59,27 @@ describe("Snappit", () => {
             });
         });
 
-        describe("after 'snappit.stop()", () => {
-            before(async () => {
+        describe("driver initialization", () => {
+            it("should create a driver instance", async () => {
+                // Snappit will throw if there is a problem in driver creation.
                 driver = snappit.start();
-                await driver.get("http://localhost:8080/");
+                await driver;
+            });
+
+            it("should navigate to the localhost page", async () => {
+                driver.get("http://localhost:8080/");
+
+                expect(await $("#color-div").isDisplayed()).to.eql(true);
+            });
+
+            it("should terminate the driver instance", async () => {
+                await snappit.stop();
+            });
+        });
+
+        describe("after 'snappit.stop()'", () => {
+            before(async () => {
+                await snappit.start();
                 await snappit.stop();
             });
 
@@ -151,144 +93,152 @@ describe("Snappit", () => {
                 expect(error).to.be.an.instanceOf(NoDriverSessionException);
             });
         });
-    });
 
-    describe("when using an existing driver", () => {
-        return null;
-    });
+        describe("screenshots", () => {
+            before(async () => {
+                driver = snappit.start();
+                await driver.get("http://localhost:8080/");
+            });
 
-    describe("when taking a screenshot", function() {
-        let snappit: Snappit;
-        let driver: ThenableWebDriver;
-        this.timeout(15000);
-        this.slow(2500);
+            after(async () => {
+                await snappit.stop();
+            });
 
-        before(async () => {
-            // Initialize Snappit
-            const config: IConfig = {
-                browser: "chrome",
-                headless: true,
-                screenshotsDir: "test/screenshots",
-                serverUrl: "http://localhost:4444/wd/hub",
-                threshold: 0.1,
-            };
-            snappit = new Snappit(config);
-            driver = snappit.start();
-            await resetViewport(driver);
-            await driver.get("http://localhost:8080/");
+            it("should throw an error if the screenshot does not exist", async () => {
+                const error = await snap("does-not-exist.png", $("#color-div")).catch((err) => err);
+                expect(error).to.be.an.instanceof(ScreenshotNoBaselineException);
+            });
+
+            it("should throw an error if the screenshot is a different size", async () => {
+                await snap("different-size.png", $("body")).catch((err) => err);
+                const error = await snap("different-size.png", $("#color-div")).catch((err) => err);
+                expect(error).to.be.an.instanceof(ScreenshotSizeDifferenceException);
+            });
+
+            it("should throw an error if the screenshot is different above threshold", async () => {
+                await snap("different-above-threshold.png", $("#color-div")).catch((err) => err);
+                $("#toggle-button").click();
+                const error = await snap("different-above-threshold.png", $("#color-div")).catch((err) => err);
+                expect(error).to.be.an.instanceof(ScreenshotMismatchException);
+            });
+
+            it("should not throw an error if the screenshot is different below threshold", async () => {
+                await snap("different-below-threshold.png", $("#color-div")).catch((err) => err);
+                $("#border-button").click();
+                await snap("different-below-threshold.png", $("#color-div"));
+            });
+
+            it("should not throw an error if the screenshot shows no difference", async () => {
+                await snap("no-difference.png", $("#color-div")).catch((err) => err);
+                await snap("no-difference.png", $("#color-div"));
+            });
+
+            it("should handle an oversized element that is larger than the viewport size", async () => {
+                await snap("chrome-throw-no-oversized-crop.png", $("#color-div")).catch((err) => err);
+                await resizeViewport(driver, 100, 100);
+                await snap("chrome-throw-no-oversized-crop.png", $("#color-div"));
+                await resizeViewport(driver);
+            });
         });
 
-        after(async () => {
-            await snappit.stop();
-        });
+        describe("re-configuration", () => {
+            before(async () => {
+                driver = snappit.start();
+                await driver.get("http://localhost:8080/");
+            });
 
-        it("should reject invalid thresholds", () => {
-            try {
-                snap.configure({ threshold: 1.01 });
-            } catch (e) {
-                expect(e.message).to.equal('Configuration error: Please set a "threshold" between 0 and 0.99');
-            }
-        });
+            after(async () => {
+                await snappit.stop();
+            });
 
-        it("should throw an error and save if the screenshot does not exist", async () => {
-            const error = await snap("does-not-exist.png", $("#color-div")).catch((err) => err);
-            expect(error).to.be.an.instanceof(ScreenshotNoBaselineException);
-            expect(fs.existsSync("./test/screenshots/does-not-exist.png")).to.eql(true);
-        });
+            it("should reject invalid thresholds", () => {
+                const fn = () => {
+                    snap.configure({ threshold: 1.01 });
+                };
+                expect(fn).to.throw('Configuration error: Please set a "threshold" between 0 and 0.99');
+            });
 
-        it("should throw an error and save if the screenshot is a different size", async () => {
-            // ignore pre-populating of baseline
-            await snap("different-size.png", $("body")).catch((err) => err);
-            const error = await snap("different-size.png", $("#color-div")).catch((err) => err);
-            expect(error).to.be.an.instanceof(ScreenshotSizeDifferenceException);
-        });
-
-        it("should throw an error and save if the screenshot is different above threshold", async () => {
-            // ignore pre-populating of baseline
-            await snap("different-above-threshold.png", $("#color-div")).catch((err) => err);
-            $("#toggle-button").click();
-            const error = await snap("different-above-threshold.png", $("#color-div")).catch((err) => err);
-            expect(error).to.be.an.instanceof(ScreenshotMismatchException);
-        });
-
-        it("should not throw an error or save if the screenshot is different below threshold", async () => {
-            // ignore pre-populating of baseline
-            await snap("different-below-threshold.png", $("#color-div")).catch((err) => err);
-            $("#border-button").click();
-            await snap("different-below-threshold.png", $("#color-div"));
-        });
-
-        it("should not throw an error or save if the screenshot shows no difference", async () => {
-            $("#border-button").click();
-            // ignore pre-populating of baseline
-            await snap("no-difference.png", $("#color-div")).catch((err) => err);
-            await snap("no-difference.png", $("#color-div"));
-        });
-
-        it("should take a screenshot with directory and path tokens", async () => {
-            const size = await driver.manage().window().getSize();
-            const version = (await driver.getCapabilities()).get("version").replace(/\W+/gi, "-");
-            const path = `./test/screenshots/chrome/${version}/${size.width}x${size.height}/test.png`;
-
-            // This will error because the screenshot does not already exist, but we only care if it's created.
-            await snap("{browserName}/{browserVersion}/{browserSize}/test.png").catch((err) => err);
-            expect(fs.existsSync(path)).to.eql(true);
-        });
-
-        it("should handle an oversized element that is larger than the viewport size", async () => {
-            await snap("chrome-throw-no-oversized-crop.png", $("#color-div")).catch((err) => err);
-            await driver.manage().window().setSize(100, 100);
-            await snap("chrome-throw-no-oversized-crop.png", $("#color-div"));
-            await resetViewport(driver);
-        });
-
-        describe("and reconfiguring at runtime", () => {
             it("should not trigger a baseline threshold error when setting the threshold very high", async () => {
                 snap.configure({ threshold: 0.99 });
-                $("#border-button").click();
+                $("#toggle-button").click();
                 const error = await snap("different-below-threshold.png", $("#color-div")).catch((err) => err);
                 expect(error).to.equal(undefined);
             });
 
             it("should trigger a baseline threshold error when setting the threshold very low", async () => {
                 snap.configure({ threshold: 0.001 });
-                $("#toggle-button").click();
+                $("#border-button").click();
                 const error = await snap("different-below-threshold.png", $("#color-div")).catch((err) => err);
                 expect(error).to.be.instanceOf(ScreenshotMismatchException);
             });
 
+            it("should not throw an error but still save if the screenshot does not exist", async () => {
+                snap.configure({ logException: [ScreenshotExceptionName.NO_BASELINE] });
+                await snap("throw-no-baseline-false.png", $("#color-div"));
+            });
+
+            it("should not throw an error but still save if the screenshot is a different size", async () => {
+                snap.configure({ logException: [ScreenshotExceptionName.SIZE_DIFFERENCE] });
+                await snap("throw-size-difference-false.png").catch((err) => err);
+                await snap("throw-size-difference-false.png", $("#color-div"));
+            });
+
+            it("should not throw an error but still save if the screenshot does not match", async () => {
+                snap.configure({ logException: [ScreenshotExceptionName.MISMATCH] });
+                await snap("throw-no-mismatch-false.png", $("#color-div")).catch((err) => err);
+                $("#border-button").click();
+                await snap("throw-no-mismatch-false.png", $("#color-div"));
+            });
+
+            it("should take a screenshot with directory and path tokens", async () => {
+                // tslint:disable-next-line:no-console
+                const size = await driver.manage().window().getSize();
+                const capabilities = await driver.getCapabilities();
+                const version = (capabilities.get("version") || capabilities.get("browserVersion"))
+                    .replace(/\W+/gi, "-");
+                const tokenPath = `${config.browser}/${version}/${size.width}x${size.height}/test.png`;
+
+                // This will error because the screenshot does not already exist, but we only care if it's created.
+                await snap("{browserName}/{browserVersion}/{browserSize}/test.png").catch((err) => err);
+                await snap(tokenPath);
+            });
         });
     });
+}
 
-    describe("when taking a screenshot with throwNoBaseline set to false", function() {
-        let snappit: Snappit;
-        let driver: ThenableWebDriver;
-        this.timeout(15000);
-        this.slow(2500);
+// tslint:disable-next-line:no-namespace
+namespace browserTest {
+    export function only(
+        suiteName: string,
+        config: IConfig,
+    ) {
+        return browserTest(suiteName, config, describe.only);
+    }
 
-        before(async () => {
-            const config: IConfig = {
-                browser: "chrome",
-                logException: [ScreenshotExceptionName.NO_BASELINE],
-                screenshotsDir: "test/screenshots",
-                threshold: 0.1,
-                useDirect: true,
-            };
+    export function skip(
+        suiteName: string,
+        config: IConfig,
+    ) {
+        return browserTest(suiteName, config, describe.skip);
+    }
+}
 
-            snappit = new Snappit(config);
-            driver = snappit.start();
-            await resetViewport(driver);
-            await driver.get("http://localhost:8080/");
-        });
+describe("Snappit", () => {
+    browserTest("Chrome", {
+        browser: "chrome",
+    });
 
-        after(async () => {
-            await snappit.stop();
-        });
+    browserTest("GeckoDriver FireFox", {
+        browser: "firefox",
+    });
 
-        it("should not throw an error but still save if the screenshot does not exist", async () => {
-            await snap("throw-no-baseline-false.png", $("#color-div"));
-            expect(fs.existsSync("./test/screenshots/throw-no-baseline-false.png")).to.eql(true);
-        });
+    browserTest("Chrome Headless", {
+        browser: "chrome",
+        headless: true,
+    });
 
+    browserTest("GeckoDriver FireFox Headless", {
+        browser: "firefox",
+        headless: true,
     });
 });


### PR DESCRIPTION
This is a work in progress. I wouldn't merge it yet as it nerfs some features/options to get a proof of concept out.

### Things to discuss/address/resolve.

 - [x] No support for anything but remote servers when using headless. Drop direct connect entirely?
 - [ ] Headless FF has to use `canvasCrop`, since it doesn't understand `element.takeScreenshot`.
 - [ ] There's no testing between headless vs. non-headless.
 - [ ] There's no testing of validate config. I can add that quickly. 