### PR TITLE
fix(snappit): Allow for calls to snappit.snap to honor default options

### DIFF
--- a/src/snappit.ts
+++ b/src/snappit.ts
@@ -134,13 +134,21 @@ export class Snappit {
     public async snap(
         name: string,
         element?: WebElement,
-        opts?: ISnapOptions,
+        opts: ISnapOptions = {
+            hide: [],
+        },
     ): Promise<void> {
         const filePath = await Screenshot.buildPath(name, this.driver, this.config.screenshotsDir);
         const shortPath = path.relative(process.cwd(), filePath);
-        await blackout.hideElements(this.driver, opts.hide);
+        if (opts.hide.length) {
+            await blackout.hideElements(this.driver, opts.hide);
+        }
+
         const newShot = await Screenshot.take(this.driver, element);
-        await blackout.unhideElements(this.driver, opts.hide);
+
+        if (opts.hide.length) {
+            await blackout.unhideElements(this.driver, opts.hide);
+        }
 
         // Baseline image exists
         if (fs.existsSync(filePath)) {


### PR DESCRIPTION
If you run the globally set `snap` function, you can run into issues when running tests in parallel.

Running `snappit.snap` steps pass this, but I forgot to set the default argument for options for this call when adding the feature.